### PR TITLE
Make C benchmark use REST VOL

### DIFF
--- a/benchmarks/C/Makefile
+++ b/benchmarks/C/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
-CFLAGS=-I$(HDF5_PATH)/include
-LIBS=-L$(HDF5_PATH)/lib/ -lhdf5 -lyaml
+CFLAGS=-I$(HDF5_PATH)/include -I$(REST_VOL_PATH)/src -g -O0
+LIBS=-L$(HDF5_PATH)/lib/ -lhdf5 -L$(REST_VOL_PATH)/build/bin -lhdf5_vol_rest -lyaml
 
 benchmark: icesat2_selection.c
 	$(CC) -o icesat2_selection $(CFLAGS)  icesat2_selection.c $(LIBS)

--- a/benchmarks/C/README.md
+++ b/benchmarks/C/README.md
@@ -1,3 +1,3 @@
-C version of the icesat2_benchmark.
+C version of the icesat2_benchmark, made to work the with the REST VOL.
 
-Requires HDF5 and libyaml. Libyaml must be installed to a system path, and the path to HDF5 must be specified by the environment variable HDF5_PATH 
+Requires HDF5, the REST VOL, and libyaml. Libyaml must be installed to a system path. Paths to HDF5 and REST VOL installation must be specified by HDF5_PATH and REST_VOL_PATH respectively. See section 2 of the [REST VOL users guide](https://github.com/HDFGroup/vol-rest/blob/master/docs/users_guide.pdf) for instructions on installing the REST VOL. 


### PR DESCRIPTION
When hosting an HSDS server on my local machine with docker, the selection test completes through Python in about 1.3 seconds, through the regular HDF5 library in about 4.4 seconds, and through the REST VOL in about 5 seconds. `hsdiff` confirmed that the final output files were identical in all cases.  

Note that the selection test won't work with any version of the REST VOL prior to the fix in HDFGroup/vol-rest#31